### PR TITLE
Update ci to fail immediately if any command has a non-zero exit code

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -9,6 +9,7 @@ presubmits:
             - '/bin/sh'
             - '-c'
             - |
+              set -euo pipefail
               yarn install --frozen-lockfile
               yarn test:all
 
@@ -22,6 +23,7 @@ presubmits:
             - '/bin/sh'
             - '-c'
             - |
+              set -euo pipefail
               yarn install --frozen-lockfile
               yarn lint:all
               yarn tsc:full


### PR DESCRIPTION
This change fixes the issue where the linter or typescript complier (tsc) can fail yet the presubmit-kbp-lint presubmit job succeeds.