### PR TITLE
Use auth app to create PR

### DIFF
--- a/.github/workflows/regen_dependabot_conf.yml
+++ b/.github/workflows/regen_dependabot_conf.yml
@@ -37,9 +37,16 @@ jobs:
           wget https://raw.githubusercontent.com/nephio-project/test-infra/main/tools/dependabot/generate_dependabot.py -O /tmp/generate_dependabot.py
           python3 /tmp/generate_dependabot.py
 
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.HELPER_APP_ID }}
+          private_key: ${{ secrets.HELPER_APP_KEY }}
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           base: ${{ github.head_ref }}
           commit-message: Regenerating Dependabot configuration
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>


### PR DESCRIPTION
Instead of using fixed token this will make use of GitHub App to generate ephemeral token for each run to keep it safer.