### PR TITLE
Exclude GitHub and workflow dirs from CI test and liner checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ name: CI
 
 on:
   pull_request:
+    paths:
+      - '**'
+      - '!.github/**'
 
 permissions:  # added using https://github.com/step-security/secure-repo
   contents: read


### PR DESCRIPTION
GitHub own files should not trigger CI linter and tests