### PR TITLE
Editors for Nephio-specific resources (1st batch).

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=18.20.0"
+    "node": "18"
   },
   "scripts": {
     "dev": "NODE_ENV=development concurrently \"yarn start\" \"yarn start-backend\"",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "16 || 18"
+    "node": ">=18.20.0"
   },
   "scripts": {
     "dev": "NODE_ENV=development concurrently \"yarn start\" \"yarn start-backend\"",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "18"
+    "node": ">=18.20.0"
   },
   "scripts": {
     "dev": "NODE_ENV=development concurrently \"yarn start\" \"yarn start-backend\"",

--- a/plugins/cad-backend/src/service/config.ts
+++ b/plugins/cad-backend/src/service/config.ts
@@ -24,6 +24,7 @@ export enum GitOpsDeliveryTool {
 export enum ClusterLocatorMethodType {
   CURRENT_CONTEXT = 'current-context',
   IN_CLUSTER = 'in-cluster',
+  LOCAL_PROXY = 'local-proxy'
 }
 
 export enum ClusterLocatorAuthProvider {
@@ -31,6 +32,7 @@ export enum ClusterLocatorAuthProvider {
   GOOGLE = 'google',
   OIDC = 'oidc',
   SERVICE_ACCOUNT = 'service-account',
+  NONE = 'none',
 }
 
 export enum OIDCTokenProvider {

--- a/plugins/cad-backend/src/service/config.ts
+++ b/plugins/cad-backend/src/service/config.ts
@@ -24,7 +24,7 @@ export enum GitOpsDeliveryTool {
 export enum ClusterLocatorMethodType {
   CURRENT_CONTEXT = 'current-context',
   IN_CLUSTER = 'in-cluster',
-  LOCAL_PROXY = 'local-proxy'
+  LOCAL_PROXY = 'local-proxy',
 }
 
 export enum ClusterLocatorAuthProvider {
@@ -41,17 +41,11 @@ export enum OIDCTokenProvider {
   OKTA = 'okta',
 }
 
-export const getMaxRequestSize = (config: Config): string => {
-  const maxRequestSize = config.getOptionalString('maxRequestSize') ?? '1mb';
+export const getMaxRequestSize = (config: Config): string =>
+  config.getOptionalString('maxRequestSize') ?? '1mb';
 
-  return maxRequestSize;
-};
-
-export const getResourcesNamespace = (config: Config): string => {
-  const namespace = config.getString('resourcesNamespace');
-
-  return namespace;
-};
+export const getResourcesNamespace = (config: Config): string =>
+  config.getString('resourcesNamespace');
 
 export const getGitOpsDeliveryTool = (config: Config): GitOpsDeliveryTool => {
   const gitOpsTool = config.getString('gitOpsDeliveryTool');

--- a/plugins/cad-backend/src/service/lib.ts
+++ b/plugins/cad-backend/src/service/lib.ts
@@ -32,8 +32,8 @@ export const getKubernetesConfig = (
     case ClusterLocatorMethodType.LOCAL_PROXY:
       kubeConfig.loadFromClusterAndUser(
         { name: 'local-proxy', server: 'http://localhost:8001' },
-        { name: 'local-user' }
-      )
+        { name: 'local-user' },
+      );
       break;
     default:
       throw new Error(

--- a/plugins/cad-backend/src/service/lib.ts
+++ b/plugins/cad-backend/src/service/lib.ts
@@ -29,6 +29,12 @@ export const getKubernetesConfig = (
     case ClusterLocatorMethodType.CURRENT_CONTEXT:
       kubeConfig.loadFromDefault();
       break;
+    case ClusterLocatorMethodType.LOCAL_PROXY:
+      kubeConfig.loadFromClusterAndUser(
+        { name: 'local-proxy', server: 'http://localhost:8001' },
+        { name: 'local-user' }
+      )
+      break;
     default:
       throw new Error(
         `Unknown cluster locator method type, ${clusterLocatorMethodType}`,

--- a/plugins/cad-backend/src/service/router.ts
+++ b/plugins/cad-backend/src/service/router.ts
@@ -62,6 +62,7 @@ const getClientAuthentication = (
 
     case ClusterLocatorAuthProvider.SERVICE_ACCOUNT:
     case ClusterLocatorAuthProvider.CURRENT_CONTEXT:
+    case ClusterLocatorAuthProvider.NONE:
       return 'none';
 
     default:

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditorSelector.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditorSelector.tsx
@@ -33,6 +33,7 @@ import { ServiceAccountEditor } from './FirstClassEditors/ServiceAccountEditor';
 import { ServiceEditor } from './FirstClassEditors/ServiceEditor';
 import { SetLabelsEditor } from './FirstClassEditors/SetLabelsEditor';
 import { PackageVariantSetEditor } from './FirstClassEditors/PackageVariantSetEditor';
+import { NephioTokenEditor } from './FirstClassEditors/NephioTokenEditor';
 import { WorkloadClusterEditor } from './FirstClassEditors/WorkloadClusterEditor';
 
 type OnUpdatedYamlFn = (yaml: string) => void;
@@ -110,6 +111,9 @@ export const FirstClassEditorSelector = ({
 
     case 'fn.kpt.dev/v1alpha1/SetLabels':
       return <SetLabelsEditor yaml={yaml} onUpdatedYaml={onUpdatedYaml} />;
+
+    case 'infra.nephio.org/v1alpha1/Token':
+      return <NephioTokenEditor yaml={yaml} onUpdatedYaml={onUpdatedYaml} />;
 
     case 'infra.nephio.org/v1alpha1/WorkloadCluster':
       return (

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditorSelector.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditorSelector.tsx
@@ -23,6 +23,7 @@ import {
   DeploymentEditor,
   StatefulSetEditor,
 } from './FirstClassEditors/DeploymentEditor';
+import { CapacityEditor } from './FirstClassEditors/CapacityEditor';
 import { IngressEditor } from './FirstClassEditors/IngressEditor';
 import { KptfileEditor } from './FirstClassEditors/KptfileEditor';
 import { NamespaceEditor } from './FirstClassEditors/NamespaceEditor';
@@ -149,6 +150,9 @@ export const FirstClassEditorSelector = ({
           packageResources={packageResources}
         />
       );
+
+    case 'req.nephio.org/v1alpha1/Capacity':
+      return <CapacityEditor yaml={yaml} onUpdatedYaml={onUpdatedYaml} />;
 
     case 'v1/ConfigMap':
       return <ConfigMapEditor yaml={yaml} onUpdatedYaml={onUpdatedYaml} />;

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditorSelector.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditorSelector.tsx
@@ -33,6 +33,7 @@ import { ServiceAccountEditor } from './FirstClassEditors/ServiceAccountEditor';
 import { ServiceEditor } from './FirstClassEditors/ServiceEditor';
 import { SetLabelsEditor } from './FirstClassEditors/SetLabelsEditor';
 import { PackageVariantSetEditor } from './FirstClassEditors/PackageVariantSetEditor';
+import { WorkloadClusterEditor } from './FirstClassEditors/WorkloadClusterEditor';
 
 type OnUpdatedYamlFn = (yaml: string) => void;
 type OnNoNamedEditorFn = () => void;
@@ -109,6 +110,11 @@ export const FirstClassEditorSelector = ({
 
     case 'fn.kpt.dev/v1alpha1/SetLabels':
       return <SetLabelsEditor yaml={yaml} onUpdatedYaml={onUpdatedYaml} />;
+
+    case 'infra.nephio.org/v1alpha1/WorkloadCluster':
+      return (
+        <WorkloadClusterEditor yaml={yaml} onUpdatedYaml={onUpdatedYaml} />
+      );
 
     case 'kpt.dev/v1/Kptfile':
       return (

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/CapacityEditor/CapacityEditor.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/CapacityEditor/CapacityEditor.tsx
@@ -1,0 +1,143 @@
+/**
+ * Copyright 2024 The Nephio Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TextField } from '@material-ui/core';
+import React, { useState } from 'react';
+import { useSetStateAndCall } from '../../../../../hooks/useSetStateAndCall';
+import { getNumber } from '../../../../../utils/string';
+import {
+  Capacity,
+  CapacityMetadata,
+  CapacitySpec,
+} from '../../../../../types/Capacity';
+import { dumpYaml, loadYaml } from '../../../../../utils/yaml';
+import { EditorAccordion, ResourceMetadataAccordion } from '../Controls';
+import { useEditorStyles } from '../styles';
+
+type OnUpdatedYamlFn = (yaml: string) => void;
+
+type ResourceEditorProps = {
+  yaml: string;
+  onUpdatedYaml: OnUpdatedYamlFn;
+};
+
+type State = {
+  metadata: CapacityMetadata;
+  spec: CapacitySpec;
+};
+
+export const CapacityEditor = ({
+  yaml,
+  onUpdatedYaml,
+}: ResourceEditorProps) => {
+  const classes = useEditorStyles();
+  const resourceYaml = loadYaml(yaml) as Capacity;
+
+  const createResourceState = (): State => ({
+    metadata: resourceYaml.metadata,
+    spec: resourceYaml.spec,
+  });
+
+  const [state, setState] = useState<State>(createResourceState());
+  const [expanded, setExpanded] = useState<string>();
+
+  const setStateAndCall = useSetStateAndCall([state, setState], newState => {
+    onUpdatedYaml(dumpYaml({ ...resourceYaml, ...newState }));
+  });
+
+  return (
+    <div className={classes.root}>
+      <ResourceMetadataAccordion
+        id="metadata"
+        state={[expanded, setExpanded]}
+        value={state.metadata}
+        onUpdate={metadata => setStateAndCall(s => ({ ...s, metadata }))}
+      />
+
+      <EditorAccordion
+        id="spec"
+        title="Capacity"
+        state={[expanded, setExpanded]}
+      >
+        {/* TODO Consider adding regex-based validation of both throughput values. */}
+        <TextField
+          label="Max Uplink Throughput"
+          variant="outlined"
+          value={state.spec.maxUplinkThroughput ?? ''}
+          onChange={e => {
+            setStateAndCall(s => ({
+              ...s,
+              spec: { ...s.spec, maxUplinkThroughput: e.target.value },
+            }));
+          }}
+          fullWidth
+        />
+
+        <TextField
+          label="Max Downlink Throughput"
+          variant="outlined"
+          value={state.spec.maxDownlinkThroughput ?? ''}
+          onChange={e => {
+            setStateAndCall(s => ({
+              ...s,
+              spec: { ...s.spec, maxDownlinkThroughput: e.target.value },
+            }));
+          }}
+          fullWidth
+        />
+
+        <TextField
+          label="Max NF Connections"
+          variant="outlined"
+          value={state.spec.maxNFConnections ?? ''}
+          onChange={e => {
+            setStateAndCall(s => ({
+              ...s,
+              spec: { ...s.spec, maxNFConnections: getNumber(e.target.value) },
+            }));
+          }}
+          fullWidth
+        />
+
+        <TextField
+          label="Max Sessions"
+          variant="outlined"
+          value={state.spec.maxSessions ?? ''}
+          onChange={e => {
+            setStateAndCall(s => ({
+              ...s,
+              spec: { ...s.spec, maxSessions: getNumber(e.target.value) },
+            }));
+          }}
+          fullWidth
+        />
+
+        <TextField
+          label="Max Subscribers"
+          variant="outlined"
+          value={state.spec.maxSubscribers ?? ''}
+          onChange={e => {
+            setStateAndCall(s => ({
+              ...s,
+              spec: { ...s.spec, maxSubscribers: getNumber(e.target.value) },
+            }));
+          }}
+          fullWidth
+        />
+      </EditorAccordion>
+    </div>
+  );
+};

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/CapacityEditor/index.ts
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/CapacityEditor/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2024 The Nephio Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { CapacityEditor } from './CapacityEditor';

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/Controls/ValueListEditorAccordion.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/Controls/ValueListEditorAccordion.tsx
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2024 The Nephio Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, TextField } from '@material-ui/core';
+import AddIcon from '@material-ui/icons/Add';
+import DeleteIcon from '@material-ui/icons/Delete';
+import React, { Fragment, useRef } from 'react';
+import { KubernetesValueList } from '../../../../../types/KubernetesResource';
+import { toLowerCase } from '../../../../../utils/string';
+import { IconButton } from '../../../../Controls';
+import { useEditorStyles } from '../styles';
+import { AccordionState, EditorAccordion } from './EditorAccordion';
+
+type ValueListEditorProps = {
+  id: string;
+  title: string;
+  state: AccordionState;
+  valueList: KubernetesValueList;
+  onUpdatedValueList: (valueList: KubernetesValueList) => void;
+};
+
+export const ValueListEditorAccordion = ({
+  id,
+  title,
+  state,
+  valueList,
+  onUpdatedValueList,
+}: ValueListEditorProps) => {
+  const refViewModel = useRef<{ value: string }[]>(
+    valueList.map(value => ({ value })),
+  );
+
+  const classes = useEditorStyles();
+
+  const valueUpdated = (): void => {
+    onUpdatedValueList(
+      refViewModel.current.map(valueHolder => valueHolder.value),
+    );
+  };
+
+  const addRow = () => {
+    refViewModel.current.push({ value: '' });
+    valueUpdated();
+  };
+
+  const description = `${refViewModel.current.length} ${toLowerCase(title)}`;
+
+  return (
+    <EditorAccordion
+      id={id}
+      state={state}
+      title={title}
+      description={description}
+    >
+      <Fragment>
+        {refViewModel.current.map((valueHolder, index) => (
+          <div className={classes.multiControlRow} key={index}>
+            <TextField
+              label="Value"
+              variant="outlined"
+              value={valueHolder.value}
+              onChange={e => {
+                valueHolder.value = e.target.value;
+                valueUpdated();
+              }}
+              fullWidth
+            />
+            <IconButton
+              title="Delete"
+              className={classes.iconButton}
+              onClick={() => {
+                refViewModel.current = refViewModel.current.filter(
+                  thisValueHolder => thisValueHolder !== valueHolder,
+                );
+                valueUpdated();
+              }}
+            >
+              <DeleteIcon />
+            </IconButton>
+          </div>
+        ))}
+
+        <Button variant="outlined" startIcon={<AddIcon />} onClick={addRow}>
+          Add {title}
+        </Button>
+      </Fragment>
+    </EditorAccordion>
+  );
+};

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/Controls/index.ts
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/Controls/index.ts
@@ -18,3 +18,4 @@ export { EditorAccordion } from './EditorAccordion';
 export { KeyValueEditorAccordion } from './KeyValueEditorAccordion';
 export { ResourceMetadataAccordion } from './ResourceMetadataAccordion';
 export { SingleTextFieldAccordion } from './SingleTextFieldAccordion';
+export { ValueListEditorAccordion } from './ValueListEditorAccordion';

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/DeploymentEditor/DeploymentEditor.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/DeploymentEditor/DeploymentEditor.tsx
@@ -22,16 +22,16 @@ import {
   Deployment,
   DeploymentMetadata,
   DeploymentStrategy,
-  LabelSelector,
 } from '../../../../../types/Deployment';
 import {
   Container,
   PodSecurityContext,
   Volume,
 } from '../../../../../types/Pod';
+import { LabelSelector } from '../../../../../types/Selectors';
 import { PackageResource } from '../../../../../utils/packageRevisionResources';
 import { dumpYaml, loadYaml } from '../../../../../utils/yaml';
-import { ResourceMetadataAccordion } from '../Controls/ResourceMetadataAccordion';
+import { ResourceMetadataAccordion } from '../Controls';
 import { useEditorStyles } from '../styles';
 import {
   Deletable,

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/DeploymentEditor/StatefulSetEditor.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/DeploymentEditor/StatefulSetEditor.tsx
@@ -23,15 +23,15 @@ import {
   PodSecurityContext,
   Volume,
 } from '../../../../../types/Pod';
+import { LabelSelector } from '../../../../../types/Selectors';
 import {
-  LabelSelector,
   StatefulSet,
   StatefulSetMetadata,
   StatefulSetUpdateStrategy,
 } from '../../../../../types/StatefulSet';
 import { PackageResource } from '../../../../../utils/packageRevisionResources';
 import { dumpYaml, loadYaml } from '../../../../../utils/yaml';
-import { ResourceMetadataAccordion } from '../Controls/ResourceMetadataAccordion';
+import { ResourceMetadataAccordion } from '../Controls';
 import { useEditorStyles } from '../styles';
 import {
   Deletable,

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/DeploymentEditor/components/DeploymentDetailsEditorAccordion.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/DeploymentEditor/components/DeploymentDetailsEditorAccordion.tsx
@@ -17,11 +17,9 @@
 import { TextField } from '@material-ui/core';
 import { clone } from 'lodash';
 import React, { Fragment, useRef, useState } from 'react';
-import {
-  DeploymentStrategy,
-  LabelSelector,
-} from '../../../../../../types/Deployment';
+import { DeploymentStrategy } from '../../../../../../types/Deployment';
 import { Volume } from '../../../../../../types/Pod';
+import { LabelSelector } from '../../../../../../types/Selectors';
 import { getNumber } from '../../../../../../utils/string';
 import { KeyValueEditorAccordion } from '../../Controls';
 import {

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/DeploymentEditor/components/StatefulSetDetailsEditorAccordion.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/DeploymentEditor/components/StatefulSetDetailsEditorAccordion.tsx
@@ -18,10 +18,8 @@ import { TextField } from '@material-ui/core';
 import { clone } from 'lodash';
 import React, { Fragment, useMemo, useRef, useState } from 'react';
 import { Volume } from '../../../../../../types/Pod';
-import {
-  LabelSelector,
-  StatefulSetUpdateStrategy,
-} from '../../../../../../types/StatefulSet';
+import { LabelSelector } from '../../../../../../types/Selectors';
+import { StatefulSetUpdateStrategy } from '../../../../../../types/StatefulSet';
 import {
   getDeployableResources,
   PackageResource,

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/NephioTokenEditor/NephioTokenEditor.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/NephioTokenEditor/NephioTokenEditor.tsx
@@ -46,6 +46,11 @@ type State = {
   spec: NephioTokenSpec;
 };
 
+const getNephioTokenDescription = (spec: NephioTokenSpec) =>
+  `Deletion policy: ${
+    spec.lifecycle?.deletionPolicy ?? DELETION_POLICY_DEFAULT
+  }`;
+
 export const NephioTokenEditor = ({
   yaml,
   onUpdatedYaml,
@@ -100,8 +105,3 @@ export const NephioTokenEditor = ({
     </div>
   );
 };
-
-const getNephioTokenDescription = (spec: NephioTokenSpec) =>
-  `Deletion policy: ${
-    spec.lifecycle?.deletionPolicy ?? DELETION_POLICY_DEFAULT
-  }`;

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/NephioTokenEditor/NephioTokenEditor.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/NephioTokenEditor/NephioTokenEditor.tsx
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import { TextField } from '@material-ui/core';
+import { SelectItem } from '@backstage/core-components';
 import React, { useState } from 'react';
+import { Select } from '../../../../Controls';
 import { useSetStateAndCall } from '../../../../../hooks/useSetStateAndCall';
 import { dumpYaml, loadYaml } from '../../../../../utils/yaml';
 import {
@@ -25,6 +26,13 @@ import {
 } from '../../../../../types/Token';
 import { EditorAccordion, ResourceMetadataAccordion } from '../Controls';
 import { useEditorStyles } from '../styles';
+
+const DELETION_POLICY_DEFAULT = 'default';
+const DELETION_POLICY_SELECT_ITEMS: SelectItem[] = [
+  { value: DELETION_POLICY_DEFAULT, label: 'Default' },
+  { value: 'delete', label: 'Delete' },
+  { value: 'orphan', label: 'Orphan' },
+];
 
 type OnUpdatedYamlFn = (yaml: string) => void;
 
@@ -72,19 +80,21 @@ export const NephioTokenEditor = ({
         state={[expanded, setExpanded]}
         description={getNephioTokenDescription(state.spec)}
       >
-        <TextField
+        <Select
           label="Deletion policy"
-          variant="outlined"
-          value={state.spec.lifecycle?.deletionPolicy ?? ''}
-          onChange={e => {
+          items={DELETION_POLICY_SELECT_ITEMS}
+          selected={
+            state.spec.lifecycle?.deletionPolicy ?? DELETION_POLICY_DEFAULT
+          }
+          onChange={value => {
             setStateAndCall(s => ({
               ...s,
-              spec: e.target.value
-                ? { lifecycle: { deletionPolicy: e.target.value } }
-                : {},
+              spec:
+                value !== DELETION_POLICY_DEFAULT
+                  ? { lifecycle: { deletionPolicy: value } }
+                  : {},
             }));
           }}
-          fullWidth
         />
       </EditorAccordion>
     </div>
@@ -92,6 +102,6 @@ export const NephioTokenEditor = ({
 };
 
 const getNephioTokenDescription = (spec: NephioTokenSpec) =>
-  spec.lifecycle?.deletionPolicy
-    ? `Deletion policy: ${spec.lifecycle.deletionPolicy}`
-    : '';
+  `Deletion policy: ${
+    spec.lifecycle?.deletionPolicy ?? DELETION_POLICY_DEFAULT
+  }`;

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/NephioTokenEditor/NephioTokenEditor.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/NephioTokenEditor/NephioTokenEditor.tsx
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2024 The Nephio Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TextField } from '@material-ui/core';
+import React, { useState } from 'react';
+import { useSetStateAndCall } from '../../../../../hooks/useSetStateAndCall';
+import { dumpYaml, loadYaml } from '../../../../../utils/yaml';
+import {
+  NephioToken,
+  NephioTokenMetadata,
+  NephioTokenSpec,
+} from '../../../../../types/Token';
+import { EditorAccordion, ResourceMetadataAccordion } from '../Controls';
+import { useEditorStyles } from '../styles';
+
+type OnUpdatedYamlFn = (yaml: string) => void;
+
+type ResourceEditorProps = {
+  yaml: string;
+  onUpdatedYaml: OnUpdatedYamlFn;
+};
+
+type State = {
+  metadata: NephioTokenMetadata;
+  spec: NephioTokenSpec;
+};
+
+export const NephioTokenEditor = ({
+  yaml,
+  onUpdatedYaml,
+}: ResourceEditorProps) => {
+  const classes = useEditorStyles();
+  const resourceYaml = loadYaml(yaml) as NephioToken;
+
+  const createResourceState = (): State => ({
+    metadata: resourceYaml.metadata,
+    spec: resourceYaml.spec,
+  });
+
+  const [state, setState] = useState<State>(createResourceState());
+  const [expanded, setExpanded] = useState<string>();
+
+  const setStateAndCall = useSetStateAndCall([state, setState], newState => {
+    onUpdatedYaml(dumpYaml({ ...resourceYaml, ...newState }));
+  });
+
+  return (
+    <div className={classes.root}>
+      <ResourceMetadataAccordion
+        id="metadata"
+        state={[expanded, setExpanded]}
+        value={state.metadata}
+        onUpdate={metadata => setStateAndCall(s => ({ ...s, metadata }))}
+      />
+
+      <EditorAccordion
+        id="lifecycle"
+        title="Lifecycle"
+        state={[expanded, setExpanded]}
+        description={getNephioTokenDescription(state.spec)}
+      >
+        <TextField
+          label="Deletion policy"
+          variant="outlined"
+          value={state.spec.lifecycle?.deletionPolicy ?? ''}
+          onChange={e => {
+            setStateAndCall(s => ({
+              ...s,
+              spec: e.target.value
+                ? { lifecycle: { deletionPolicy: e.target.value } }
+                : {},
+            }));
+          }}
+          fullWidth
+        />
+      </EditorAccordion>
+    </div>
+  );
+};
+
+const getNephioTokenDescription = (spec: NephioTokenSpec) =>
+  spec.lifecycle?.deletionPolicy
+    ? `Deletion policy: ${spec.lifecycle.deletionPolicy}`
+    : '';

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/NephioTokenEditor/index.ts
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/NephioTokenEditor/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2024 The Nephio Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { NephioTokenEditor } from './NephioTokenEditor';

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/WorkloadClusterEditor/WorkloadClusterEditor.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/WorkloadClusterEditor/WorkloadClusterEditor.tsx
@@ -42,6 +42,16 @@ type State = {
   spec: WorkloadClusterSpec;
 };
 
+const getWorkloadClusterConfigurationDescription = (
+  spec: WorkloadClusterSpec,
+) =>
+  [
+    `Name: ${spec.clusterName}`,
+    spec.masterInterface ? `master interface: ${spec.masterInterface}` : null,
+  ]
+    .filter(Boolean)
+    .join(', ');
+
 export const WorkloadClusterEditor = ({
   yaml,
   onUpdatedYaml,
@@ -123,13 +133,3 @@ export const WorkloadClusterEditor = ({
     </div>
   );
 };
-
-const getWorkloadClusterConfigurationDescription = (
-  spec: WorkloadClusterSpec,
-) =>
-  [
-    `Name: ${spec.clusterName}`,
-    spec.masterInterface ? `master interface: ${spec.masterInterface}` : null,
-  ]
-    .filter(Boolean)
-    .join(', ');

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/WorkloadClusterEditor/WorkloadClusterEditor.tsx
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/WorkloadClusterEditor/WorkloadClusterEditor.tsx
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2024 The Nephio Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { dumpYaml, loadYaml } from '../../../../../utils/yaml';
+import {
+  WorkloadCluster,
+  WorkloadClusterMetadata,
+  WorkloadClusterSpec,
+} from '../../../../../types/WorkloadCluster';
+import React, { Fragment, useEffect, useState } from 'react';
+import {
+  EditorAccordion,
+  ResourceMetadataAccordion,
+  ValueListEditorAccordion,
+} from '../Controls';
+import { useEditorStyles } from '../styles';
+import { TextField } from '@material-ui/core';
+
+// FIXME This function is wildly duplicated across editor code.
+type OnUpdatedYamlFn = (yaml: string) => void;
+
+type ResourceEditorProps = {
+  yaml: string;
+  onUpdatedYaml: OnUpdatedYamlFn;
+};
+
+type State = {
+  metadata: WorkloadClusterMetadata;
+  spec: WorkloadClusterSpec;
+};
+
+const getDescription = (spec: WorkloadClusterSpec) =>
+  [
+    `Name: ${spec.clusterName}`,
+    spec.masterInterface ? `master interface: ${spec.masterInterface}` : null,
+  ]
+    .filter(Boolean)
+    .join(', ');
+
+export const WorkloadClusterEditor = ({
+  yaml,
+  onUpdatedYaml,
+}: ResourceEditorProps) => {
+  const resourceYaml = loadYaml(yaml) as WorkloadCluster;
+
+  const createResourceState = (): State => ({
+    metadata: resourceYaml.metadata,
+    spec: resourceYaml.spec,
+  });
+
+  const [state, setState] = useState<State>(createResourceState());
+  const [expanded, setExpanded] = useState<string>();
+
+  const classes = useEditorStyles();
+
+  useEffect(() => {
+    onUpdatedYaml(
+      dumpYaml({
+        ...resourceYaml,
+        metadata: state.metadata,
+        spec: state.spec,
+      }),
+    );
+  }, [state, onUpdatedYaml, resourceYaml]); // FIXME
+
+  return (
+    <div className={classes.root}>
+      <ResourceMetadataAccordion
+        id="metadata"
+        state={[expanded, setExpanded]}
+        value={state.metadata}
+        onUpdate={metadata => setState(s => ({ ...s, metadata }))}
+      />
+
+      <EditorAccordion
+        id="configuration"
+        title="Configuration"
+        state={[expanded, setExpanded]}
+        description={getDescription(state.spec)}
+      >
+        <Fragment>
+          <TextField
+            label="Cluster name"
+            variant="outlined"
+            value={state.spec.clusterName}
+            onChange={e => {
+              setState(s => ({
+                ...s,
+                spec: { ...s.spec, clusterName: e.target.value },
+              }));
+            }}
+            fullWidth
+          />
+
+          <TextField
+            label="Master interface"
+            variant="outlined"
+            value={state.spec.masterInterface}
+            onChange={e => {
+              setState(s => ({
+                ...s,
+                spec: {
+                  ...s.spec,
+                  masterInterface: e.target.value || undefined,
+                },
+              }));
+            }}
+            fullWidth
+          />
+        </Fragment>
+      </EditorAccordion>
+
+      <ValueListEditorAccordion
+        id="cnis"
+        title="CNIs"
+        state={[expanded, setExpanded]}
+        valueList={state.spec.cnis ?? []}
+        onUpdatedValueList={cnis => {
+          setState(s => ({
+            ...s,
+            spec: { ...s.spec, cnis: cnis.length > 0 ? cnis : undefined },
+          }));
+        }}
+      />
+    </div>
+  );
+};

--- a/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/WorkloadClusterEditor/index.ts
+++ b/plugins/cad/src/components/ResourceEditorDialog/components/FirstClassEditors/WorkloadClusterEditor/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2024 The Nephio Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,4 @@
  * limitations under the License.
  */
 
-export type KubernetesResource = {
-  kind: string;
-  apiVersion: string;
-  metadata: KubernetesResourceMetadata;
-};
-
-export type KubernetesResourceMetadata = {
-  name: string;
-  namespace?: string;
-  labels?: KubernetesKeyValueObject;
-  annotations?: KubernetesKeyValueObject;
-};
-
-export type KubernetesKeyValueObject = {
-  [key: string]: string;
-};
-
-export type KubernetesValueList = readonly string[];
+export { WorkloadClusterEditor } from './WorkloadClusterEditor';

--- a/plugins/cad/src/hooks/useSetStateAndCall.ts
+++ b/plugins/cad/src/hooks/useSetStateAndCall.ts
@@ -1,0 +1,16 @@
+import { Dispatch, SetStateAction, useCallback } from 'react';
+
+type SetStateAndCallFn<S> = (createNewState: (currentState: S) => S) => void;
+
+export const useSetStateAndCall = <S extends object>(
+  [state, setState]: [S, Dispatch<SetStateAction<S>>],
+  callback: (newState: S) => void,
+): SetStateAndCallFn<S> =>
+  useCallback(
+    createNewState => {
+      const newState = createNewState(state);
+      setState(newState);
+      callback(newState);
+    },
+    [state, setState, callback],
+  );

--- a/plugins/cad/src/types/Capacity.ts
+++ b/plugins/cad/src/types/Capacity.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2024 The Nephio Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { KubernetesKeyValueObject } from './KubernetesResource';
+
+export type Capacity = {
+  readonly apiVersion: string;
+  readonly kind: string;
+  readonly metadata: CapacityMetadata;
+  readonly spec: CapacitySpec;
+};
+
+export type CapacityMetadata = {
+  readonly name: string;
+  readonly namespace?: string;
+  readonly labels?: KubernetesKeyValueObject;
+  readonly annotations?: KubernetesKeyValueObject;
+};
+
+export type CapacitySpec = {
+  readonly maxDownlinkThroughput?: string;
+  readonly maxUplinkThroughput?: string;
+  readonly maxNFConnections?: number;
+  readonly maxSessions?: number;
+  readonly maxSubscribers?: number;
+};

--- a/plugins/cad/src/types/Deployment.ts
+++ b/plugins/cad/src/types/Deployment.ts
@@ -16,6 +16,7 @@
 
 import { KubernetesKeyValueObject } from './KubernetesResource';
 import { PodTemplateSpec } from './Pod';
+import { LabelSelector } from './Selectors';
 
 export type Deployment = {
   apiVersion: string;
@@ -39,10 +40,6 @@ export type DeploymentSpec = {
   minReadySeconds?: number;
   progressDeadlineSeconds?: number;
   revisionHistoryLimit?: number;
-};
-
-export type LabelSelector = {
-  matchLabels: KubernetesKeyValueObject;
 };
 
 export type DeploymentStrategy = {

--- a/plugins/cad/src/types/Selectors.ts
+++ b/plugins/cad/src/types/Selectors.ts
@@ -13,28 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { KubernetesKeyValueObject } from './KubernetesResource';
 
-/*
- * TODO Similar type definitions are heavily duplicated across types directory.
- *      Introduce generic types which can be used instead.
- */
-export type WorkloadCluster = {
-  readonly apiVersion: string;
-  readonly kind: string;
-  readonly metadata: WorkloadClusterMetadata;
-  readonly spec: WorkloadClusterSpec;
+export type LabelSelector = {
+  matchLabels: KubernetesKeyValueObject;
 };
 
-export type WorkloadClusterMetadata = {
-  readonly name: string;
-  readonly namespace?: string;
-  readonly labels?: KubernetesKeyValueObject;
-  readonly annotations?: KubernetesKeyValueObject;
+export type LabelAndExpressionSelector = {
+  readonly matchLabels: KubernetesKeyValueObject;
+  readonly matchExpressions: readonly KubernetesLabelSelectorRequirement[];
 };
 
-export type WorkloadClusterSpec = {
-  readonly clusterName: string;
-  readonly cnis?: readonly string[];
-  readonly masterInterface?: string;
+export type KubernetesLabelSelectorRequirement = {
+  readonly key: string;
+  readonly operator: KubernetesLabelSelectorOperator;
+  readonly values?: readonly string[];
 };
+
+export enum KubernetesLabelSelectorOperator {
+  In = 'In',
+  NotIn = 'NotIn',
+  Exists = 'Exists',
+  DoesNotExist = 'DoesNotExist',
+}

--- a/plugins/cad/src/types/StatefulSet.ts
+++ b/plugins/cad/src/types/StatefulSet.ts
@@ -17,6 +17,7 @@
 import { KubernetesKeyValueObject } from './KubernetesResource';
 import { PersistentVolumeClaim } from './PersistentVolumeClaim';
 import { PodTemplateSpec } from './Pod';
+import { LabelSelector } from './Selectors';
 
 export type StatefulSet = {
   apiVersion: string;
@@ -42,10 +43,6 @@ export type StatefulSetSpec = {
   revisionHistoryLimit?: number;
   minReadySeconds?: number;
   volumeClaimTemplates?: PersistentVolumeClaim[];
-};
-
-export type LabelSelector = {
-  matchLabels: KubernetesKeyValueObject;
 };
 
 export type StatefulSetUpdateStrategy = {

--- a/plugins/cad/src/types/Token.ts
+++ b/plugins/cad/src/types/Token.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2024 The Nephio Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { KubernetesKeyValueObject } from './KubernetesResource';
+
+export type NephioToken = {
+  readonly apiVersion: string;
+  readonly kind: string;
+  readonly metadata: NephioTokenMetadata;
+  readonly spec: NephioTokenSpec;
+};
+
+export type NephioTokenMetadata = {
+  readonly name: string;
+  readonly namespace?: string;
+  readonly labels?: KubernetesKeyValueObject;
+  readonly annotations?: KubernetesKeyValueObject;
+};
+
+export type NephioTokenSpec = {
+  readonly lifecycle?: {
+    readonly deletionPolicy?: string;
+  };
+};

--- a/plugins/cad/src/types/WorkloadCluster.ts
+++ b/plugins/cad/src/types/WorkloadCluster.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2024 The Nephio Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { KubernetesKeyValueObject } from './KubernetesResource';
+
+// FIXME These type definitions are duplicated across types directory.
+
+export type WorkloadCluster = {
+  readonly apiVersion: string;
+  readonly kind: string;
+  readonly metadata: WorkloadClusterMetadata;
+  readonly spec: WorkloadClusterSpec;
+};
+
+export type WorkloadClusterMetadata = {
+  readonly name: string;
+  readonly namespace?: string;
+  readonly labels?: KubernetesKeyValueObject;
+  readonly annotations?: KubernetesKeyValueObject;
+};
+
+export type WorkloadClusterSpec = {
+  readonly clusterName: string;
+  readonly cnis?: readonly string[];
+  readonly masterInterface?: string;
+};


### PR DESCRIPTION
This PR adds three new editor UIs for resource types which are specific to Nephio:
- `infra.nephio.org/v1alpha1/WorkloadCluster`
- `infra.nephio.org/v1alpha1/Token`
- `req.nephio.org/v1alpha1/Capacity`

----

At this moment, the Web UI project does not support GUI editor functionality for any of Nephio-specific resource types. This PR is the beginning of a bigger effort which aims to close this gap and provide graphical editors for all relevant Nephio resources.

This PR follows previously established practices and editor creation conventions, which involve significant code repetition. Following PRs will aim to rework existing and new editors in a way which promotes code reuse and adheres to DRY principles.


----

![image](https://github.com/user-attachments/assets/7c33afc4-9a73-40d3-9d46-5773a802655a)

_Example of `WorkloadCluster` editor._

----

Additional tweaks and fixes include:
- Added `LOCAL_PROXY` configuration mode, which makes it possible for WebUI developers to connect application to a Kubernetes proxy. SSH port forwarding can be used to easily connect to a remote cluster.
- Created `useSetStateAndCall` React hook which aims to limit undesirable usage of `useEffect` hook for reacting to state changes.