### PR TITLE
Update better-sqlite3 from 7.5.0 to 11.8.0

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -26,7 +26,7 @@
     "@backstage/plugin-proxy-backend": "^0.4.16",
     "@kpt/backstage-plugin-cad-backend": "*",
     "app": "link:../app",
-    "better-sqlite3": "^7.5.0",
+    "better-sqlite3": "^11.8.0",
     "dockerode": "^3.3.1",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",


### PR DESCRIPTION
Fixes [#862](https://github.com/nephio-project/nephio/issues/862).

This update is needed for better-sqlite3 to be compatible with the latest NodeJS version. Passes test cases on Ubuntu 24.04.1.

