### PR TITLE
Display resources for .yml files

### DIFF
--- a/plugins/cad/src/utils/packageRevision.ts
+++ b/plugins/cad/src/utils/packageRevision.ts
@@ -25,17 +25,9 @@ import {
 } from '../types/PackageRevision';
 import { toLowerCase } from './string';
 
-const getRevisionNumber = (revision: string, defaultNumber: number = NaN): number => {
-  if (revision && revision.startsWith('v')) {
-    const revisionNumber = parseInt(revision.substring(1), 10);
-
-    if (Number.isInteger(revisionNumber)) {
-      return revisionNumber;
-    }
-  }
-
-  return defaultNumber;
-};
+function getRevisionNumber(revision: number): number {
+  return revision;
+}
 
 const getNextRevision = (revision: string): string => {
   const revisionNumber = getRevisionNumber(revision, 0);

--- a/plugins/cad/src/utils/packageRevision.ts
+++ b/plugins/cad/src/utils/packageRevision.ts
@@ -25,9 +25,17 @@ import {
 } from '../types/PackageRevision';
 import { toLowerCase } from './string';
 
-function getRevisionNumber(revision: number): number {
-  return revision;
-}
+const getRevisionNumber = (revision: string, defaultNumber: number = NaN): number => {
+  if (revision && revision.startsWith('v')) {
+    const revisionNumber = parseInt(revision.substring(1), 10);
+
+    if (Number.isInteger(revisionNumber)) {
+      return revisionNumber;
+    }
+  }
+
+  return defaultNumber;
+};
 
 const getNextRevision = (revision: string): string => {
   const revisionNumber = getRevisionNumber(revision, 0);

--- a/plugins/cad/src/utils/packageRevisionResources.ts
+++ b/plugins/cad/src/utils/packageRevisionResources.ts
@@ -109,7 +109,11 @@ export const getPackageRevisionResourcesResource = (
 
 export const getPackageResourcesFromResourcesMap = (resourcesMap: PackageRevisionResourcesMap): PackageResource[] => {
   const yamlFileEntries = Object.entries(resourcesMap).filter(
-    file => file[0].endsWith('.yaml') || file[0] === 'Kptfile' || file[0].endsWith('/Kptfile'),
+    file => 
+      file[0].endsWith('.yaml') || 
+      file[0].endsWith('.yml') ||
+      file[0] === 'Kptfile' || 
+      file[0].endsWith('/Kptfile'),
   );
 
   const resources = yamlFileEntries.map(([filename, multiResourceYaml]) => {

--- a/plugins/cad/src/utils/packageRevisionResources.ts
+++ b/plugins/cad/src/utils/packageRevisionResources.ts
@@ -120,8 +120,9 @@ export const getPackageResourcesFromResourcesMap = (resourcesMap: PackageRevisio
     const resourcesYaml = getResourcesFromMultiResourceYaml(multiResourceYaml);
 
     return resourcesYaml.map((resourceYaml, index) => {
-      const k8sResource = loadYaml(resourceYaml) as KubernetesResource;
+      const k8sResource = loadYaml(resourceYaml) as KubernetesResource | null;
 
+      if (!k8sResource) return null;
       const uniqueId = `${k8sResource.kind}:${filename ?? k8sResource.metadata.name}:${index}`;
 
       return {

--- a/plugins/cad/src/utils/packageRevisionResources.ts
+++ b/plugins/cad/src/utils/packageRevisionResources.ts
@@ -116,16 +116,16 @@ export const getPackageResourcesFromResourcesMap = (resourcesMap: PackageRevisio
       file[0].endsWith('/Kptfile'),
   );
 
-  const resources = yamlFileEntries.map(([filename, multiResourceYaml]) => {
+  const resources = yamlFileEntries.flatMap(([filename, multiResourceYaml]) => {
     const resourcesYaml = getResourcesFromMultiResourceYaml(multiResourceYaml);
 
-    return resourcesYaml.map((resourceYaml, index) => {
+    return resourcesYaml.flatMap((resourceYaml, index) => {
       const k8sResource = loadYaml(resourceYaml) as KubernetesResource | null;
 
-      if (!k8sResource) return null;
+      if (!k8sResource) return [];
       const uniqueId = `${k8sResource.kind}:${filename ?? k8sResource.metadata.name}:${index}`;
 
-      return {
+      return [{
         id: uniqueId,
         component: filename.substring(0, filename.lastIndexOf('/')),
         filename: filename,
@@ -135,11 +135,11 @@ export const getPackageResourcesFromResourcesMap = (resourcesMap: PackageRevisio
         yaml: resourceYaml,
         resourceIndex: index,
         isLocalConfigResource: !!k8sResource.metadata.annotations?.['config.kubernetes.io/local-config'],
-      };
+      }];
     });
   });
 
-  return resources.flat();
+  return resources;
 };
 
 const getResourcesForFile = (resourcesMap: PackageRevisionResourcesMap, filename: string): string[] => {

--- a/plugins/cad/src/utils/packageRevisionResources.ts
+++ b/plugins/cad/src/utils/packageRevisionResources.ts
@@ -109,11 +109,8 @@ export const getPackageRevisionResourcesResource = (
 
 export const getPackageResourcesFromResourcesMap = (resourcesMap: PackageRevisionResourcesMap): PackageResource[] => {
   const yamlFileEntries = Object.entries(resourcesMap).filter(
-    file => 
-      file[0].endsWith('.yaml') || 
-      file[0].endsWith('.yml') ||
-      file[0] === 'Kptfile' || 
-      file[0].endsWith('/Kptfile'),
+    file =>
+      file[0].endsWith('.yaml') || file[0].endsWith('.yml') || file[0] === 'Kptfile' || file[0].endsWith('/Kptfile'),
   );
 
   const resources = yamlFileEntries.flatMap(([filename, multiResourceYaml]) => {
@@ -125,17 +122,19 @@ export const getPackageResourcesFromResourcesMap = (resourcesMap: PackageRevisio
       if (!k8sResource) return [];
       const uniqueId = `${k8sResource.kind}:${filename ?? k8sResource.metadata.name}:${index}`;
 
-      return [{
-        id: uniqueId,
-        component: filename.substring(0, filename.lastIndexOf('/')),
-        filename: filename,
-        kind: k8sResource.kind,
-        name: k8sResource.metadata.name,
-        namespace: k8sResource.metadata.namespace,
-        yaml: resourceYaml,
-        resourceIndex: index,
-        isLocalConfigResource: !!k8sResource.metadata.annotations?.['config.kubernetes.io/local-config'],
-      }];
+      return [
+        {
+          id: uniqueId,
+          component: filename.substring(0, filename.lastIndexOf('/')),
+          filename: filename,
+          kind: k8sResource.kind,
+          name: k8sResource.metadata.name,
+          namespace: k8sResource.metadata.namespace,
+          yaml: resourceYaml,
+          resourceIndex: index,
+          isLocalConfigResource: !!k8sResource.metadata.annotations?.['config.kubernetes.io/local-config'],
+        },
+      ];
     });
   });
 


### PR DESCRIPTION
Fixes [#355](https://github.com/nephio-project/nephio/issues/355)

Display resources from .yml files and add null check to allow comment blocks in yaml files-- Example in the first resource block in [multus-daemonset-thick.yml](https://github.com/nephio-project/nephio-example-packages/blob/main/multus/multus-daemonset-thick.yml) from nephio-example-packages which previously caused a runtime error if you tried to view its resources.